### PR TITLE
fix catch-value warning

### DIFF
--- a/include/setimmediate.h
+++ b/include/setimmediate.h
@@ -81,7 +81,7 @@ void SetImmediate(napi_env env, T&& cb) {
 
     try {
       cb();
-    } catch (Napi::Error e) {
+    } catch (Napi::Error& e) {
       // This is going to crash, but it's not like we really have a choice.
       e.ThrowAsJavaScriptException();
     }


### PR DESCRIPTION
Without ref:
```bash
make: Entering directory '/home/kirill/tmp/weak/weak-napi/build'
  CC(target) Release/obj.target/nothing/node_modules/node-addon-api/src/nothing.o
  AR(target) Release/obj.target/node_modules/node-addon-api/src/nothing.a
  COPY Release/nothing.a
  CXX(target) Release/obj.target/weakref/src/weakref.o
In file included from ../src/weakref.cc:2:
../node_modules/setimmediate-napi/include/setimmediate.h: In instantiation of ‘void SetImmediate(napi_env, T&&) [with T = {anonymous}::ObjectInfo::OnFree()::<lambda()>; napi_env = napi_env__*]’:
../src/weakref.cc:25:6:   required from here
../node_modules/setimmediate-napi/include/setimmediate.h:46:7: warning: catching polymorphic type ‘class Napi::Error’ by value [-Wcatch-value=]
   46 |     } catch (Napi::Error e) {
      |       ^~~~~
  SOLINK_MODULE(target) Release/obj.target/weakref.node
  COPY Release/weakref.node
make: Leaving directory '/home/kirill/tmp/weak/weak-napi/build'
```

with this PR:
```bash
make: Entering directory '/home/kirill/tmp/weak/weak-napi/build'
  CC(target) Release/obj.target/nothing/node_modules/node-addon-api/src/nothing.o
  AR(target) Release/obj.target/node_modules/node-addon-api/src/nothing.a
  COPY Release/nothing.a
  CXX(target) Release/obj.target/weakref/src/weakref.o
  SOLINK_MODULE(target) Release/obj.target/weakref.node
  COPY Release/weakref.node
make: Leaving directory '/home/kirill/tmp/weak/weak-napi/build'
```